### PR TITLE
Comment out the KeyPadMode enable feature flag checks

### DIFF
--- a/src/terminal/input/terminalInput.cpp
+++ b/src/terminal/input/terminalInput.cpp
@@ -451,7 +451,7 @@ try
         // the ASCII character assigned by the keyboard layout, but when set
         // they transmit SS3 escape sequences. When used with a modifier, the
         // modifier is embedded as a parameter value (not standard).
-        if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
+        /*if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
         {
             defineNumericKey(VK_MULTIPLY, L'j');
             defineNumericKey(VK_ADD, L'k');
@@ -472,7 +472,7 @@ try
             defineNumericKey(VK_NUMPAD9, L'y');
 
             defineNumericKey(Enhanced + VK_RETURN, L'M');
-        }
+        }*/
     }
     else
     {
@@ -503,7 +503,7 @@ try
 
         // Keypad keys also depend on Keypad mode, the same as ANSI mappings,
         // but the sequences use an ESC ? prefix instead of SS3.
-        if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
+        /*if (Feature_KeypadModeEnabled::IsEnabled() && _inputMode.test(Mode::Keypad))
         {
             defineKeyWithUnusedModifiers(VK_MULTIPLY, L"\033?j"s);
             defineKeyWithUnusedModifiers(VK_ADD, L"\033?k"s);
@@ -524,7 +524,7 @@ try
             defineKeyWithUnusedModifiers(VK_NUMPAD9, L"\033?y"s);
 
             defineKeyWithUnusedModifiers(Enhanced + VK_RETURN, L"\033?M"s);
-        }
+        }*/
     }
 
     _focusInSequence = _csi + L"I"s;


### PR DESCRIPTION
## Summary of the Pull Request
Comment out the `KeyPadModeEnabled` feature flag checks in order to fix the bug where `.` is converted `n` with certain keyboards.

For more information on this change, see https://github.com/warpdotdev/warp-internal/pull/14158
